### PR TITLE
Group Property Validation Messages

### DIFF
--- a/src/Sequin.FluentValidation/Middleware/ValidateCommand.cs
+++ b/src/Sequin.FluentValidation/Middleware/ValidateCommand.cs
@@ -52,7 +52,10 @@
             var result = validator.Validate(command);
             if (!result.IsValid)
             {
-                var errors = result.Errors.ToDictionary(x => x.PropertyName, x => x.ErrorMessage);
+                var errors = result.Errors
+                    .GroupBy(k => k.PropertyName)
+                    .ToDictionary(g => g.Key, g => g.Select(x => x.ErrorMessage));
+
                 context.Response.BadRequest("The command contained validation errors.");
                 context.Response.Json(errors);
             }


### PR DESCRIPTION
Updates the fluent validation error response to group the invalid property messages together.

This would be better if a ErrorResponseFormatter object was passed in to allow the user to format the error responses. 